### PR TITLE
docs: use server option instead of host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const app = Fastify({
 
 const mssqlPlugin = require('fastify-mssql')
 app.register(mssqlPlugin, {
-  host: 'my-host',
+  server: 'my-host',
   port: 1433,
   user: 'my-user',
   password: 'my-password',


### PR DESCRIPTION
The plugin uses the server property, but the sample code is supplying host, which leaves server with the default value of localhost. This changes host to server which works correctly.