### PR TITLE
Use types form mssql package 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ MSSQL Plugin for Fastify.
 npm install fastify-mssql
 ```
 
+You will also need to have mssql dependency installed and @types/mssql when you are using TypeScript.
+
+```
+npm install mssql @types/mssql
+```
+
 ## Usage
 
 ### Example

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -2,13 +2,7 @@ import * as MSSql from 'mssql'
 
 import { FastifyInstance, FastifyPluginAsync } from 'fastify';
 
-export interface MSSQLPluginOptions {
-  server?: string
-  port?: number
-  user?: string
-  password?: string
-  database?: string
-}
+export interface MSSQLPluginOptions extends MSSql.config {}
 
 export interface MSSQLFastifyInterface {
   pool: MSSql.ConnectionPool,


### PR DESCRIPTION
Have a look at the changes. One is adding the dependencies as non-dev ones. They are required to run this dependency,  not just to develop it.

Second changes uses options from the mssql package which is in any case used and everything is passed to it. Not just the few properties.