### PR TITLE
Add decorate property to MSSQL plugin configuration

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -2,7 +2,9 @@ import * as MSSql from 'mssql'
 
 import { FastifyInstance, FastifyPluginAsync } from 'fastify';
 
-export interface MSSQLPluginOptions extends MSSql.config {}
+export interface MSSQLPluginOptions extends MSSql.config {
+  decorate: string
+}
 
 export interface MSSQLFastifyInterface {
   pool: MSSql.ConnectionPool,

--- a/plugin.js
+++ b/plugin.js
@@ -4,6 +4,7 @@ const fp = require('fastify-plugin')
 const MSSql = require('mssql')
 
 const defaults = {
+  decorate: 'mssql',
   server: 'localhost',
   port: 1433,
   user: 'sa',
@@ -23,7 +24,7 @@ const plugin = async (fastify, config) => {
   fastify.addHook('onClose', async () => {
     await pool.close()
   })
-  fastify.decorate('mssql', {
+  fastify.decorate(connectionConfig.decorate, {
     pool,
     sqlTypes: MSSql
   })


### PR DESCRIPTION
This pull request introduces the option to configure the decorate property in the MSSQL plugin for Fastify. This allows users to customize the name used to decorate the Fastify instance with the MSSQL pool and types.

**Changes Made:**
Added decorate property in the defaults object.
Updated fastify.decorate to use connectionConfig.decorate.

**Why this change is necessary:**
This change provides more flexibility for users of the Fastify MSSQL plugin. By allowing the customization of the decoration name, it prevents potential naming conflicts and gives users more control over their Fastify instance.
This customization will allow multiple DB connection.

**Testing:**
Have replicated the test case to use custom decorate name.
Verified that the plugin works with the default decorate value.
Tested the plugin with a custom decorate value to ensure it decorates the Fastify instance correctly